### PR TITLE
fix Class 'unreal4u\MQTT\DataTypes\Topic' not found error

### DIFF
--- a/examples/d1-subscribeOneTopic.php
+++ b/examples/d1-subscribeOneTopic.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 use unreal4u\MQTT\Client;
 use unreal4u\MQTT\DataTypes\QoSLevel;
-use unreal4u\MQTT\DataTypes\Topic;
+use unreal4u\MQTT\Application\Topic;
 use unreal4u\MQTT\Protocol\Connect;
 use unreal4u\MQTT\Protocol\Connect\Parameters;
 use unreal4u\MQTT\Protocol\Subscribe;


### PR DESCRIPTION
The include directive is wrong in this example.
 I haven't checked other examples yet.